### PR TITLE
Added support for BBCode groups

### DIFF
--- a/core/acp_manager.php
+++ b/core/acp_manager.php
@@ -203,6 +203,28 @@ class acp_manager
 	}
 
 	/**
+	 * Get the bbcode_group data from the database, for every BBCode that has groups assigned
+	 *
+	 * @return array Custom BBCode user group ids for each BBCode, by name
+	 * @access public
+	 */
+	public function get_bbcode_groups_data()
+	{
+		$sql = 'SELECT bbcode_tag, bbcode_group
+			FROM ' . BBCODES_TABLE . "
+			WHERE bbcode_group > ''";
+		$result = $this->db->sql_query($sql);
+		$groups = array();
+		while ($row = $this->db->sql_fetchrow($result))
+		{
+			$groups[$row['bbcode_tag']] = explode(',', $row['bbcode_group']);
+		}
+		$this->db->sql_freeresult($result);
+
+		return $groups;
+	}
+
+	/**
 	 * Generate a select box containing user groups
 	 *
 	 * @param mixed $select_id The user groups to mark as selected

--- a/core/acp_manager.php
+++ b/core/acp_manager.php
@@ -217,7 +217,7 @@ class acp_manager
 		$groups = array();
 		while ($row = $this->db->sql_fetchrow($result))
 		{
-			$groups[$row['bbcode_tag']] = explode(',', $row['bbcode_group']);
+			$groups[$row['bbcode_tag']] = $row['bbcode_group'];
 		}
 		$this->db->sql_freeresult($result);
 

--- a/event/acp_listener.php
+++ b/event/acp_listener.php
@@ -50,6 +50,7 @@ class acp_listener implements EventSubscriberInterface
 			'core.acp_bbcodes_display_bbcodes'			=> 'acp_bbcodes_custom_sorting_buttons',
 			'core.acp_bbcodes_modify_create'			=> 'acp_bbcodes_modify_create',
 			'core.acp_bbcodes_edit_add'					=> 'acp_bbcodes_group_select_box',
+			'core.text_formatter_s9e_configure_after'	=> 's9e_store_bbcode_groups',
 		);
 	}
 
@@ -148,5 +149,22 @@ class acp_listener implements EventSubscriberInterface
 		$hidden_fields = $event['hidden_fields'];
 		$hidden_fields['bbcode_group'] = $bbcode_group;
 		$event['hidden_fields'] = $hidden_fields;
+	}
+
+	/**
+	 * Store BBCode groups in a s9e\TextFormatter variable
+	 *
+	 * @param object $event The event object
+	 * @return null
+	 * @access public
+	 */
+	public function s9e_store_bbcode_groups($event)
+	{
+		$configurator = $event['configurator'];
+		$bbcode_groups = $this->acp_manager->get_bbcode_groups_data();
+
+		// Save BBCode groups in a registered variable in the configurator. That variable will be
+		// copied in the parser's configuration and be available during parser setup
+		$configurator->registeredVars['abbc3.bbcode_groups'] = $bbcode_groups;
 	}
 }

--- a/event/listener.php
+++ b/event/listener.php
@@ -95,6 +95,9 @@ class listener implements EventSubscriberInterface
 			// message_parser events
 			'core.modify_format_display_text_after'		=> 'parse_bbcodes_after',
 			'core.modify_bbcode_init'					=> 'allow_custom_bbcodes',
+
+			// text_formatter events
+			'core.text_formatter_s9e_parser_setup'		=> 's9e_allow_custom_bbcodes',
 		);
 	}
 
@@ -198,5 +201,27 @@ class listener implements EventSubscriberInterface
 	public function allow_custom_bbcodes($event)
 	{
 		$event['bbcodes'] = $this->bbcodes_display->allow_custom_bbcodes($event['bbcodes'], $event['rowset']);
+	}
+
+	/**
+	 * Toggle custom BBCodes in the s9e\TextFormatter parser based on user's group memberships
+	 *
+	 * @param object $event The event object
+	 * @return null
+	 * @access public
+	 */
+	public function s9e_allow_custom_bbcodes($event)
+	{
+		// Get the s9e\TextFormatter\Parser object from the text_formatter.parser service
+		$service = $event['parser'];
+		$parser = $service->get_parser();
+		foreach ($parser->registeredVars['abbc3.bbcode_groups'] as $bbcode_name => $groups)
+		{
+			if (!$this->bbcodes_display->user_in_bbcode_group($groups))
+			{
+				$bbcode_name = rtrim($bbcode_name, '=');
+				$service->disable_bbcode($bbcode_name);
+			}
+		}
 	}
 }

--- a/tests/event/acp_listener_test.php
+++ b/tests/event/acp_listener_test.php
@@ -31,6 +31,7 @@ class acp_listener_test extends acp_listener_base
 			'core.acp_bbcodes_display_bbcodes',
 			'core.acp_bbcodes_modify_create',
 			'core.acp_bbcodes_edit_add',
+			'core.text_formatter_s9e_configure_after',
 		), array_keys(\vse\abbc3\event\acp_listener::getSubscribedEvents()));
 	}
 }

--- a/tests/event/event_listener_test.php
+++ b/tests/event/event_listener_test.php
@@ -35,6 +35,7 @@ class event_listener_test extends event_listener_base
 			'core.display_custom_bbcodes_modify_row',
 			'core.modify_format_display_text_after',
 			'core.modify_bbcode_init',
+			'core.text_formatter_s9e_parser_setup',
 		), array_keys(\vse\abbc3\event\listener::getSubscribedEvents()));
 	}
 }


### PR DESCRIPTION
This adds support for BBCode groups. The list of groups for each BBCode is saved with the parser so that it doesn't have to be retrieved from the database every time. The cached parser is invalidated every time a BBCode is edited so the data should always be current.

You'll have to update the composer dependency for s9e/text-formatter or you may see a PHP notice under some circumstances. I tested it manually on my local installation and it worked fine. I didn't write any unit test for it though, I'll leave that to you. :sweat_smile:

Feel free to rename any symbols (method names, variable names, etc...) or move the code to a different class as you see fit.