### PR TITLE
Only set BBCODE_IMG if it is not set already

### DIFF
--- a/core/bbcodes_display.php
+++ b/core/bbcodes_display.php
@@ -73,7 +73,10 @@ class bbcodes_display
 
 		$bbcode_img = 'abbc3/images/icons/' . strtolower(rtrim($row['bbcode_tag'], '=')) . '.gif';
 
-		$custom_tags['BBCODE_IMG'] = (isset($images['ext/' . $bbcode_img])) ? 'ext/vse/' . $bbcode_img : '';
+		if(!isset($custom_tags['BBCODE_IMG']))
+		{
+			$custom_tags['BBCODE_IMG'] = (isset($images['ext/' . $bbcode_img])) ? 'ext/vse/' . $bbcode_img : '';
+		}
 		$custom_tags['S_CUSTOM_BBCODE_ALLOWED'] = (!empty($row['bbcode_group'])) ? $this->user_in_bbcode_group($row['bbcode_group']) : true;
 
 		return $custom_tags;

--- a/core/bbcodes_display.php
+++ b/core/bbcodes_display.php
@@ -73,7 +73,7 @@ class bbcodes_display
 
 		$bbcode_img = 'abbc3/images/icons/' . strtolower(rtrim($row['bbcode_tag'], '=')) . '.gif';
 
-		if(!isset($custom_tags['BBCODE_IMG']))
+		if (!isset($custom_tags['BBCODE_IMG']))
 		{
 			$custom_tags['BBCODE_IMG'] = (isset($images['ext/' . $bbcode_img])) ? 'ext/vse/' . $bbcode_img : '';
 		}


### PR DESCRIPTION
This allows other extensions to provide their own icons for the BBcode Box, without having to pay attention to listener priorities.
Possible use-cases:
 * phpBB MathJax: https://github.com/marcovo/phpbb_mathjax
 * phpBB [hide] code: https://github.com/marcovo/phpbb_hidebbcode